### PR TITLE
Fix Wikidata subclass query

### DIFF
--- a/wikidata/2019_subclassof_tree.sql
+++ b/wikidata/2019_subclassof_tree.sql
@@ -1,13 +1,13 @@
-CREATE OR REPLACE TABLE `wikidata.subclasses_20190822`
+CREATE OR REPLACE TABLE `wikidata.subclasses_2019`
 AS
 
 SELECT a.*, b.en_label subclass_of_label, 1 level
 FROM (
   SELECT a.numeric_id, en_label, b.numeric_id subclass_of_numeric_id
-  FROM `fh-bigquery.wikidata.wikidata_latest_20190822` a, UNNEST(a.subclass_of) b
+  FROM `fh-bigquery.wikidata.wikidata_2019` a, UNNEST(a.subclass_of) b
   WHERE a.type = 'item'
 ) a
-JOIN `fh-bigquery.wikidata.wikidata_latest_20190822` b
+JOIN `fh-bigquery.wikidata.wikidata_2019` b
 ON a.subclass_of_numeric_id = b.numeric_id AND b.type = 'item'
 ;
 
@@ -15,21 +15,21 @@ LOOP
   BEGIN
     DECLARE row_count INT64;
     DECLARE row_diff INT64;
-    SET row_count = (SELECT COUNT(*) FROM `wikidata.subclasses_20190822`) 
+    SET row_count = (SELECT COUNT(*) FROM `wikidata.subclasses_2019`) 
     ;
 
 
-    INSERT INTO `wikidata.subclasses_20190822`
+    INSERT INTO `wikidata.subclasses_2019`
 
     SELECT a.numeric_id, a.en_label, b.subclass_of_numeric_id, b.subclass_of_label, MIN(b.level+1) level
-    FROM `wikidata.subclasses_20190822` a
-    JOIN `wikidata.subclasses_20190822` b
+    FROM `wikidata.subclasses_2019` a
+    JOIN `wikidata.subclasses_2019` b
     ON a.subclass_of_numeric_id = b.numeric_id
-    WHERE STRUCT(a.numeric_id,b.subclass_of_numeric_id) NOT IN (SELECT STRUCT(numeric_id,subclass_of_numeric_id) FROM `wikidata.subclasses_20190822`)
+    WHERE STRUCT(a.numeric_id,b.subclass_of_numeric_id) NOT IN (SELECT STRUCT(numeric_id,subclass_of_numeric_id) FROM `wikidata.subclasses_2019`)
     GROUP BY 1,2,3,4
     ;
 
-    SET row_diff = (SELECT COUNT(*) FROM `wikidata.subclasses_20190822`) - row_count;
+    SET row_diff = (SELECT COUNT(*) FROM `wikidata.subclasses_2019`) - row_count;
     IF row_diff = 0 THEN
         LEAVE;
     END IF;

--- a/wikidata/2019_subclassof_tree.sql
+++ b/wikidata/2019_subclassof_tree.sql
@@ -5,9 +5,10 @@ SELECT a.*, b.en_label subclass_of_label, 1 level
 FROM (
   SELECT a.numeric_id, en_label, b.numeric_id subclass_of_numeric_id
   FROM `fh-bigquery.wikidata.wikidata_latest_20190822` a, UNNEST(a.subclass_of) b
+  WHERE a.type = 'item'
 ) a
 JOIN `fh-bigquery.wikidata.wikidata_latest_20190822` b
-ON a.subclass_of_numeric_id=b.numeric_id
+ON a.subclass_of_numeric_id = b.numeric_id AND b.type = 'item'
 ;
 
 LOOP

--- a/wikidata/2019_subclassof_tree.sql
+++ b/wikidata/2019_subclassof_tree.sql
@@ -21,7 +21,7 @@ LOOP
 
     INSERT INTO `wikidata.subclasses_2019`
 
-    SELECT a.numeric_id, a.en_label, b.subclass_of_numeric_id, b.subclass_of_label, MIN(b.level+1) level
+    SELECT a.numeric_id, a.en_label, b.subclass_of_numeric_id, b.subclass_of_label, MIN(a.level + b.level) level
     FROM `wikidata.subclasses_2019` a
     JOIN `wikidata.subclasses_2019` b
     ON a.subclass_of_numeric_id = b.numeric_id


### PR DESCRIPTION
This PR fixes a bug in the query used to create the table `fh-bigquery.wikidata.subclasses_20190822`. The query uses a `numeric_id` instead of the full Wikidata ID and correctly matches an entry with its correct parent but also any numerically-matching Wikidata property. 

As a result, an query for the parent classes of an item like [Q18599 short-term memory](https://www.wikidata.org/wiki/Q18599) would return both its superclass [Q492 memory](https://www.wikidata.org/wiki/Q492) as well as the unrelated property [P492 OMIM ID](https://www.wikidata.org/wiki/Property:P492):

```sql
SELECT * FROM `fh-bigquery.wikidata.subclasses_20190822` where numeric_id = 18599 and level = 1;
```

This PR simply excludes Wikidata properties with the filter `type='item'`.